### PR TITLE
fix: remove langfuse-ergonomic from release-plz config

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -20,10 +20,3 @@ name = "langfuse-client-base"
 # This is auto-generated, so we might want to handle it specially
 changelog_update = false
 publish = true
-
-[[package]]
-name = "langfuse-ergonomic"  
-changelog_update = true
-publish = true
-# Ensure base client is published first
-publish_allow_dirty = false


### PR DESCRIPTION
The langfuse-ergonomic crate has been moved to its own repository. This PR removes the reference to it from the release-plz configuration.

This fixes the release-plz workflow error where it was looking for a crate that doesn't exist in this repository.