### PR TITLE
fix: remove workspace configuration from release-plz

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,4 +1,4 @@
-# Clippy configuration for the workspace
+# Clippy configuration for generated code
 
 # Allow generated code to have more relaxed linting rules
 allow-dbg-in-tests = true

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,9 +1,8 @@
 # Configuration for release-plz
 # https://release-plz.ieni.dev/docs/config
 
-[workspace]
 # Enable changelog generation
-changelog_update = true
+changelog_update = false  # No changelog for generated code
 
 # Enable git releases and tags
 git_release_enable = true
@@ -14,9 +13,5 @@ pr_labels = ["release"]
 pr_draft = false
 pr_name = "chore: release version {{version}}"
 
-# Package-specific configuration
-[[package]]
-name = "langfuse-client-base"
-# This is auto-generated, so we might want to handle it specially
-changelog_update = false
+# Publishing
 publish = true


### PR DESCRIPTION
Fixes the release-plz warning about README path by removing workspace configuration.

This is a single-package repository, not a workspace, so release-plz should use root-level configuration instead of [workspace] configuration.

This should fix the warning:
```
README path '/tmp/.tmpkAvkKt/langfuse-client-base/../README.md' doesn't exist
```