### PR TITLE
fix: correct release-plz.toml configuration syntax

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,8 +1,9 @@
 # Configuration for release-plz
 # https://release-plz.ieni.dev/docs/config
 
-# Enable changelog generation
-changelog_update = false  # No changelog for generated code
+[workspace]
+# Disable changelog generation for generated code
+changelog_update = false
 
 # Enable git releases and tags
 git_release_enable = true


### PR DESCRIPTION
Fix the release-plz.toml configuration by placing settings under the [workspace] section as required by the latest version of release-plz.

This resolves the CI failure that was occurring with the error:
```
unknown field `changelog_update`, expected one of `workspace`, `changelog`, `package`
```