### PR TITLE
feat: add nightly client generation workflow

### DIFF
--- a/.github/workflows/generate-client.yml
+++ b/.github/workflows/generate-client.yml
@@ -1,0 +1,113 @@
+name: Generate Client
+
+on:
+  schedule:
+    # Run every night at 2 AM UTC
+    - cron: '0 2 * * *'
+  workflow_dispatch: # Allow manual triggering
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install OpenAPI Generator
+        run: |
+          npm install -g @openapitools/openapi-generator-cli@2.13.14
+          openapi-generator-cli version
+
+      - name: Generate client
+        run: |
+          ./scripts/generate-openapi-client.sh
+
+      - name: Check for changes
+        id: check_changes
+        run: |
+          git diff --exit-code || echo "has_changes=true" >> $GITHUB_OUTPUT
+
+      - name: Create Pull Request
+        if: steps.check_changes.outputs.has_changes == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: 'chore: update generated client from latest OpenAPI spec'
+          title: 'chore: update generated client from latest OpenAPI spec'
+          body: |
+            ## 🤖 Auto-generated Update
+            
+            This PR updates the generated client based on the latest OpenAPI specification from Langfuse.
+            
+            ### Changes
+            - Updated generated code in `src/` from latest OpenAPI spec
+            - Applied automatic formatting
+            
+            ### Pre-merge Checklist
+            - [ ] Review the changes to ensure they look reasonable
+            - [ ] Check that the build passes
+            - [ ] Verify no breaking changes for downstream consumers
+            
+            ---
+            *This PR was automatically created by the nightly generation workflow.*
+          branch: auto/update-generated-client
+          delete-branch: true
+          labels: |
+            dependencies
+            automated
+
+  keepalive:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Keepalive Workflow
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            // This step ensures the workflow stays active even during periods of inactivity
+            // GitHub disables scheduled workflows after 60 days of repository inactivity
+            
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const workflow_id = 'generate-client.yml';
+            
+            // Get the workflow
+            const workflow = await github.rest.actions.getWorkflow({
+              owner,
+              repo,
+              workflow_id
+            });
+            
+            console.log(`Workflow ${workflow.data.name} is ${workflow.data.state}`);
+            
+            // If the workflow is disabled, re-enable it
+            if (workflow.data.state === 'disabled_inactivity') {
+              await github.rest.actions.enableWorkflow({
+                owner,
+                repo,
+                workflow_id
+              });
+              console.log('Workflow re-enabled');
+            }
+            
+            // Log the last run to show activity
+            const runs = await github.rest.actions.listWorkflowRuns({
+              owner,
+              repo,
+              workflow_id,
+              per_page: 1
+            });
+            
+            if (runs.data.workflow_runs.length > 0) {
+              const lastRun = runs.data.workflow_runs[0];
+              console.log(`Last run: ${lastRun.created_at} - Status: ${lastRun.status}`);
+            }


### PR DESCRIPTION
## Summary

Adds automated nightly generation of the OpenAPI client with automatic PR creation when changes are detected.

## Features

### 🌙 Nightly Generation
- Runs every night at 2 AM UTC
- Downloads latest OpenAPI spec from Langfuse
- Regenerates the client code
- Creates a PR only when there are actual changes

### 🔄 Keepalive Mechanism
- Prevents GitHub from disabling the workflow after 60 days of inactivity
- Checks workflow status on each run
- Automatically re-enables if disabled
- Logs activity to maintain repository freshness

### 🤖 Automated PR Creation
- Uses `peter-evans/create-pull-request` action
- Creates PRs to `auto/update-generated-client` branch
- Includes proper labels and description
- Auto-deletes branch after merge

## How it Works

1. **Schedule**: Runs nightly via cron schedule
2. **Generation**: Executes `./scripts/generate-openapi-client.sh`
3. **Change Detection**: Checks if any files were modified
4. **PR Creation**: Only creates PR if changes detected
5. **Keepalive**: Ensures workflow stays active even during quiet periods

## Benefits

- ✅ Stay up-to-date with latest Langfuse API changes
- ✅ No manual intervention needed
- ✅ Won't spam with empty PRs
- ✅ Won't get disabled by GitHub's inactivity policy
- ✅ Can be manually triggered via workflow_dispatch

## Related Configuration

The repository also has:
- **Renovate**: Runs weekly (Mondays) for dependency updates
- **Release-plz**: Handles version bumps and releases

Together, these ensure the repository stays active and up-to-date.