### PR TITLE
fix: use latest OpenAPI Generator version in workflow

### DIFF
--- a/.github/workflows/generate-client.yml
+++ b/.github/workflows/generate-client.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Install OpenAPI Generator
         run: |
-          npm install -g @openapitools/openapi-generator-cli@2.13.14
+          npm install -g @openapitools/openapi-generator-cli
           openapi-generator-cli version
 
       - name: Generate client


### PR DESCRIPTION
## Summary

Fixes the nightly generation workflow by removing the hardcoded OpenAPI Generator version that doesn't exist.

## Problem
The workflow was failing with:
```
npm error notarget No matching version found for @openapitools/openapi-generator-cli@2.13.14
```

## Solution
Use the latest version by not specifying a version number, which matches what the generation script does.

## Testing
The workflow should now successfully:
1. Install the latest OpenAPI Generator CLI
2. Run the generation script
3. Create a PR if there are changes

Fixes the failure seen in: https://github.com/genai-rs/langfuse-client-base/actions/runs/17320847728