### PR TITLE
fix: bump to 0.2.0 due to breaking MSRV change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.2] - 2025-01-29
+## [0.2.0] - 2025-01-29
 
-### Changed
-- Upgraded MSRV from 1.75.0 to 1.82.0
+### Breaking Changes
+- Upgraded MSRV from 1.75.0 to 1.82.0 (requires Rust 1.82+)
 - Upgraded reqwest from 0.11 to 0.12
 - Enabled changelog generation in release-plz
 
@@ -51,7 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Choice of TLS backend (rustls or native-tls)
 - Strong typing with serde
 
-[Unreleased]: https://github.com/genai-rs/langfuse-client-base/compare/v0.1.2...HEAD
-[0.1.2]: https://github.com/genai-rs/langfuse-client-base/compare/v0.1.1...v0.1.2
+[Unreleased]: https://github.com/genai-rs/langfuse-client-base/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/genai-rs/langfuse-client-base/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/genai-rs/langfuse-client-base/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/genai-rs/langfuse-client-base/releases/tag/v0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "langfuse-client-base"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 authors = ["Tim Van Wassenhove <github@timvw.be>"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary

This PR correctly bumps the version to 0.2.0 instead of 0.1.2 because:

- MSRV (Minimum Supported Rust Version) changes are breaking changes
- Users on Rust 1.75.0-1.81.x can no longer use the library
- According to semver, breaking changes require a major version bump (0.1.x → 0.2.0 for pre-1.0)

## Changes
- Update version in Cargo.toml to 0.2.0
- Update CHANGELOG to reflect this is a breaking change
- Mark MSRV change as a breaking change in the changelog

Once this is merged, release-plz will create the correct release PR for version 0.2.0.