### PR TITLE
fix: let release-plz handle version bump

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "langfuse-client-base"
-version = "0.2.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["Tim Van Wassenhove <github@timvw.be>"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Release-plz needs to manage the version bump itself. This PR reverts the manual version change so release-plz can properly create a release PR for 0.2.0.