### PR TITLE
fix: sync Cargo.toml version with crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "langfuse-client-base"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 authors = ["Tim Van Wassenhove <github@timvw.be>"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary

Quick fix to sync the version in Cargo.toml with what's already published on crates.io.

## Problem
- Version 0.2.0 was successfully published to crates.io earlier today
- However, Cargo.toml still has version 0.1.1
- This mismatch causes release-plz to fail with:
  ```
  package langfuse-client-base has a different version (0.1.1) with respect to 
  the registry package (0.2.0), but the git tag v0.1.1 exists
  ```

## Solution
- Update Cargo.toml version to 0.2.0 to match crates.io
- This will allow release-plz to work correctly for future releases

## Failed workflow
https://github.com/genai-rs/langfuse-client-base/actions/runs/17327301761