### PR TITLE
fix: enable rebase merge for linear history

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -25,9 +25,9 @@ repository:
   default_branch: main
   
   # Merge settings
-  allow_squash_merge: true
+  allow_squash_merge: false
   allow_merge_commit: false
-  allow_rebase_merge: false
+  allow_rebase_merge: true
   allow_auto_merge: false
   delete_branch_on_merge: true
   allow_update_branch: true
@@ -63,7 +63,7 @@ branches:
       restrictions: null
       
       # Other settings
-      required_linear_history: false
+      required_linear_history: true
       allow_force_pushes: false
       allow_deletions: false
       block_creations: false


### PR DESCRIPTION
## Summary

Switch from squash merging to rebase merging to maintain linear history with individual commits preserved.

## Changes

- **Disable squash merge** - No longer combines all commits into one
- **Enable rebase merge** - Maintains linear history  
- **Enable required linear history** - Enforces no merge commits

## Benefits

✅ Clean linear git history (no merge commits)
✅ Individual commits preserved (better for bisecting, blame, etc.)
✅ Each commit remains atomic and reviewable
✅ Easier to cherry-pick individual changes

The Settings app will apply these changes automatically when merged.