### PR TITLE
fix: update deny.toml to version 2 format

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -2,13 +2,15 @@
 # https://github.com/EmbarkStudios/cargo-deny
 
 [advisories]
-# Deny known security vulnerabilities
-vulnerability = "deny"
-unmaintained = "warn"
+# Use version 2 for stricter defaults
+version = 2
+# Allow unmaintained crates in dependencies but not in workspace
+unmaintained = "transitive"
 yanked = "warn"
-notice = "warn"
 
 [licenses]
+# Use version 2 for stricter defaults
+version = 2
 # Allow common open source licenses
 allow = [
     "MIT",
@@ -16,12 +18,9 @@ allow = [
     "Apache-2.0 WITH LLVM-exception",
     "BSD-3-Clause",
     "ISC",
-    "Unicode-DFS-2016",
+    "Unicode-3.0",
+    "CDLA-Permissive-2.0",
 ]
-
-copyleft = "warn"
-unlicensed = "deny"
-default = "deny"
 
 [[licenses.exceptions]]
 # Ring uses a custom license but is widely trusted
@@ -37,8 +36,6 @@ highlight = "all"
 # Skip certain crates that commonly have multiple versions
 skip = [
     { name = "windows-sys" },
-    { name = "windows_x86_64_gnu" },
-    { name = "windows_x86_64_msvc" },
 ]
 
 [sources]


### PR DESCRIPTION
## Summary
- Migrate cargo-deny configuration to version 2 format
- Fix license allowlist to include Unicode-3.0 and CDLA-Permissive-2.0
- Remove deprecated configuration fields

## Changes
- Updated deny.toml to use version 2 format for both advisories and licenses sections
- Replaced deprecated fields (vulnerability, copyleft, unlicensed, default) with version 2 defaults
- Added Unicode-3.0 license (used by ICU crates in idna dependency chain)
- Added CDLA-Permissive-2.0 license (used by webpki-roots)
- Removed unnecessary skip entries for single-version crates
- Set unmaintained to 'transitive' to allow unmaintained crates in dependencies

## Why this fix was needed
The Security (Comprehensive) workflow was failing on main branch due to incorrect deny.toml configuration. The configuration was using deprecated fields that are no longer valid in newer versions of cargo-deny.

Fixes the failed workflow: https://github.com/genai-rs/langfuse-client-base/actions/runs/17332580194