### PR TITLE
fix: correct TruffleHog configuration for push events

### DIFF
--- a/.github/workflows/secrets.yml
+++ b/.github/workflows/secrets.yml
@@ -24,8 +24,10 @@ jobs:
         uses: trufflesecurity/trufflehog@main
         with:
           path: ./
-          base: ${{ github.event.repository.default_branch }}
-          head: HEAD
+          # For PRs: scan from base to head
+          # For pushes: scan the commits in the push
+          base: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          head: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.event.after }}
           extra_args: --only-verified
 
   gitleaks:


### PR DESCRIPTION
## Summary
Fixes the failing TruffleHog workflow when pushing to main branch.

## Problem
TruffleHog was failing with "BASE and HEAD commits are the same" error when pushing to main because it was comparing main branch to HEAD, which are the same on a push event.

## Solution
- For push events: Use `github.event.before` and `github.event.after` to scan the actual commits in the push
- For pull_request events: Use PR base/head SHAs as before
- This ensures TruffleHog always has a valid range of commits to scan

## Testing
The workflow will now properly scan:
- New commits when pushing to main
- Differences between PR branch and base branch for pull requests

Fixes: https://github.com/genai-rs/langfuse-client-base/actions/runs/17333751394