### PR TITLE
docs: add crate-level documentation from README

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![doc = include_str!("../README.md")]
 #![allow(unused_imports)]
 #![allow(clippy::too_many_arguments)]
 


### PR DESCRIPTION
## Summary

Add crate-level documentation by including README.md content in src/lib.rs.

## Why this change is needed

Without this change:
- The crate lacks proper documentation on docs.rs
- Users won't see the README content as the main crate documentation
- Missing critical information about this being a low-level client
- Users won't see the recommendation to use `langfuse-ergonomic` for most use cases

## What this PR does

Adds a single line to src/lib.rs:
```rust
#![doc = include_str!("../README.md")]
```

This ensures the README content appears as the crate-level documentation on docs.rs, providing users with:
- Clear warning that most users should use langfuse-ergonomic instead
- Usage examples and configuration instructions
- Platform-specific notes for different TLS backends
- Links to the higher-level ergonomic wrapper