### PR TITLE
chore: automerge core dependency updates

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -114,7 +114,7 @@
       minimumReleaseAge: '0 days',
     },
     {
-      description: 'Core dependencies - manual review required',
+      description: 'Core dependencies',
       matchPackageNames: [
         'serde',
         'reqwest',
@@ -124,10 +124,7 @@
         'dependencies',
         'core',
       ],
-      automerge: false,
-      assignees: [
-        'timvw',
-      ],
+      automerge: true,
     },
     {
       description: 'Dev dependencies - auto-merge all',


### PR DESCRIPTION
## Summary
- Enable automerge for core dependencies (serde, reqwest, tokio) — CI already validates compilation and tests
- Remove manual assignee requirement for these updates

## Test plan
- [ ] Verify next Renovate PR for a core dep auto-merges after CI passes