### PR TITLE
fix(generate): strip OpenAPI 3.1 const keyword so nightly client generation succeeds

### DIFF
--- a/scripts/normalize_openapi_schema.py
+++ b/scripts/normalize_openapi_schema.py
@@ -2,12 +2,22 @@
 
 """Normalize OpenAPI schema constructs that break Rust code generation.
 
-Currently normalizes invalid numeric schema combinations where a node is
-declared as `type: integer` with `format: float|double`.
+Normalizations applied:
 
-OpenAPI treats floating-point values as `type: number` with
-`format: float|double`. Keeping `type: integer` there can lead to duplicate
-generated enum variants in Rust.
+1. Invalid numeric schema combinations where a node is declared as
+   `type: integer` with `format: float|double`. OpenAPI treats floating-point
+   values as `type: number` with `format: float|double`. Keeping
+   `type: integer` there can lead to duplicate generated enum variants in Rust.
+
+2. The JSON-Schema / OpenAPI-3.1 `const` keyword. The upstream Langfuse spec
+   declares `openapi: 3.0.1` yet uses `const` (e.g. on
+   `unstableCodeEvaluationRuleEvaluatorReference.type`), which OpenAPI Generator
+   rejects during 3.0 spec validation with:
+
+       attribute components.schemas.<name>.const is unexpected
+
+   `const: X` is semantically a single-value enum, so we drop the line, leaving
+   the plain `type:`/`description:` that a 3.0 document expects.
 """
 
 from __future__ import annotations
@@ -19,10 +29,40 @@ from pathlib import Path
 
 TYPE_RE = re.compile(r"^(\s*)(-\s*)?type:\s*([\"']?)([^\"'#\s]+)([\"']?)(\s*(#.*)?)$")
 FORMAT_RE = re.compile(r"^\s*format:\s*([\"']?)([^\"'#\s]+)([\"']?)(\s*(#.*)?)$")
+# Match the `const` schema keyword only when it carries an inline *scalar*
+# value (e.g. `const: code`). The first value character must not be `#` (a
+# comment, i.e. a bare `const:` property key) nor `{`/`[` (an inline flow
+# collection -- see limitation below).
+#
+# Known limitation: const values that are collections rather than scalars are
+# left untouched, whether block-form (`const:` opening an indented mapping /
+# sequence) or inline flow-form (`const: {...}` / `const: [...]`). A line-based
+# pass cannot tell such a schema keyword apart from a property literally named
+# "const" without full structural parsing. Upstream only uses inline scalar
+# const; if that ever changes, spec validation fails loudly and this can be
+# revisited.
+CONST_RE = re.compile(r"^\s*(?:-\s+)*([\"']?)const\1:\s+(?![#{[])\S.*$")
+# A node whose value introduces a YAML block scalar (`|`, `>`, with optional
+# chomping/indent indicators in either order -- `|-`, `|2`, `|2-`, `>4+` -- and
+# a trailing comment). Its indented body is free text, so any `const:` lines
+# within it must be preserved. Matched against the content past any leading
+# `- ` sequence markers, so it covers both `key: |` and bare `- |` forms.
+BLOCK_SCALAR_RE = re.compile(r"^(?:[^:#]+:\s*)?[|>][+\-0-9]*\s*(#.*)?$")
 
 
 def _leading_spaces(line: str) -> int:
     return len(line) - len(line.lstrip(" "))
+
+
+def _content_indent(line: str) -> int:
+    """Column where a node's content begins, past indentation and `- ` markers."""
+    i = _leading_spaces(line)
+    length = len(line)
+    while i + 1 < length and line[i] == "-" and line[i + 1] == " ":
+        i += 2
+        while i < length and line[i] == " ":
+            i += 1
+    return i
 
 
 def _strip_quotes(value: str) -> str:
@@ -90,23 +130,70 @@ def normalize_text(text: str) -> tuple[str, int]:
     return "".join(lines), changes
 
 
+def strip_const_keyword(text: str) -> tuple[str, int]:
+    """Drop OpenAPI-3.1 `const` keyword lines that break 3.0 spec validation."""
+    lines = text.splitlines(keepends=True)
+    kept = []
+    changes = 0
+
+    # Indentation of the node introducing the block scalar we are currently
+    # inside, or None when not inside one. Body lines are anything indented
+    # deeper (blank lines belong to the body too).
+    block_indent: int | None = None
+
+    for line in lines:
+        stripped = line.rstrip("\n")
+
+        if block_indent is not None:
+            if stripped.strip() == "" or _leading_spaces(stripped) > block_indent:
+                # Still inside the block scalar body -- preserve verbatim.
+                kept.append(line)
+                continue
+            block_indent = None
+
+        content_col = _content_indent(stripped)
+        content = stripped[content_col:]
+        if BLOCK_SCALAR_RE.match(content):
+            # A bare `- |` entry is indented relative to its dash; a `key: |`
+            # value is indented relative to the key. Track whichever applies so
+            # the body threshold is correct in both cases.
+            block_indent = (
+                _leading_spaces(stripped) if content[0] in "|>" else content_col
+            )
+            kept.append(line)
+            continue
+
+        if CONST_RE.match(stripped):
+            changes += 1
+            continue
+
+        kept.append(line)
+
+    return "".join(kept), changes
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(
-        description="Normalize OpenAPI numeric type declarations."
+        description="Normalize OpenAPI schema constructs for Rust generation."
     )
     parser.add_argument("spec", type=Path, help="Path to OpenAPI YAML file")
     args = parser.parse_args()
 
     content = args.spec.read_text(encoding="utf-8")
-    normalized, changes = normalize_text(content)
+    normalized, numeric_changes = normalize_text(content)
+    normalized, const_changes = strip_const_keyword(normalized)
+    changes = numeric_changes + const_changes
 
     if changes > 0:
         args.spec.write_text(normalized, encoding="utf-8")
-        print(
-            f"Normalized {changes} schema entr{'y' if changes == 1 else 'ies'} in {args.spec}"
-        )
+        details = []
+        if numeric_changes:
+            details.append(f"{numeric_changes} numeric type(s)")
+        if const_changes:
+            details.append(f"{const_changes} const keyword(s)")
+        print(f"Normalized {', '.join(details)} in {args.spec}")
     else:
-        print(f"No numeric schema normalization needed in {args.spec}")
+        print(f"No schema normalization needed in {args.spec}")
 
     return 0
 

--- a/tests/test_normalize_openapi_schema.py
+++ b/tests/test_normalize_openapi_schema.py
@@ -9,6 +9,7 @@ assert SPEC is not None and SPEC.loader is not None
 MODULE = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(MODULE)
 normalize_text = MODULE.normalize_text
+strip_const_keyword = MODULE.strip_const_keyword
 
 
 class NormalizeOpenApiSchemaTests(unittest.TestCase):
@@ -38,6 +39,74 @@ class NormalizeOpenApiSchemaTests(unittest.TestCase):
         self.assertEqual(changes, 1)
         self.assertIn("- type: number", normalized)
         self.assertIn("format: double", normalized)
+
+
+class StripConstKeywordTests(unittest.TestCase):
+    def test_inline_schema_const_is_stripped(self) -> None:
+        source = "        type:\n          type: string\n          const: code\n"
+
+        stripped, changes = strip_const_keyword(source)
+
+        self.assertEqual(changes, 1)
+        self.assertNotIn("const: code", stripped)
+        self.assertIn("type: string", stripped)
+
+    def test_quoted_schema_const_is_stripped(self) -> None:
+        source = '        type:\n          type: string\n          "const": code\n'
+
+        stripped, changes = strip_const_keyword(source)
+
+        self.assertEqual(changes, 1)
+        self.assertNotIn("const", stripped)
+
+    def test_property_named_const_is_preserved(self) -> None:
+        source = "      properties:\n        const:  # literal property name\n          type: string\n"
+
+        stripped, changes = strip_const_keyword(source)
+
+        self.assertEqual(changes, 0)
+        self.assertEqual(stripped, source)
+
+    def test_const_text_inside_block_scalar_is_preserved(self) -> None:
+        source = "        description: |\n          Example usage:\n            const: code\n          keep this line\n"
+
+        stripped, changes = strip_const_keyword(source)
+
+        self.assertEqual(changes, 0)
+        self.assertEqual(stripped, source)
+
+    def test_block_scalar_with_indent_and_chomping_indicators(self) -> None:
+        source = "        description: |2-\n          const: keep\n        next: value\n"
+
+        stripped, changes = strip_const_keyword(source)
+
+        self.assertEqual(changes, 0)
+        self.assertIn("const: keep", stripped)
+
+    def test_sibling_const_after_sequence_block_scalar_is_stripped(self) -> None:
+        source = "      - description: |\n          body text\n        const: code\n"
+
+        stripped, changes = strip_const_keyword(source)
+
+        self.assertEqual(changes, 1)
+        self.assertIn("body text", stripped)
+        self.assertNotIn("const: code", stripped)
+
+    def test_property_named_const_with_inline_schema_is_preserved(self) -> None:
+        source = "      properties:\n        const: { type: string, description: literal property }\n        keep:\n          type: string\n"
+
+        stripped, changes = strip_const_keyword(source)
+
+        self.assertEqual(changes, 0)
+        self.assertEqual(stripped, source)
+
+    def test_bare_sequence_block_scalar_body_is_preserved(self) -> None:
+        source = "      examples:\n        - |\n          const: literal\n        - type: string\n"
+
+        stripped, changes = strip_const_keyword(source)
+
+        self.assertEqual(changes, 0)
+        self.assertIn("const: literal", stripped)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

The nightly **Generate Client** workflow ([example failing run](https://github.com/genai-rs/langfuse-client-base/actions/runs/28919813512)) has been failing for a while. OpenAPI Generator v7.22.0 aborts during spec validation, before generating anything:

```
org.openapitools.codegen.SpecValidationException: There were issues with the specification.
Error count: 1
Errors:
  -attribute components.schemas.unstableCodeEvaluationRuleEvaluatorReference.const is unexpected
```

## Root cause

Langfuse's upstream spec added a schema (`unstableCodeEvaluationRuleEvaluatorReference`) that uses the JSON-Schema / OpenAPI-3.1 `const` keyword:

```yaml
type:
  type: string
  const: code
```

But the spec declares `openapi: 3.0.1`, where `const` is not a valid attribute. **Upgrading the generator does not help** — the validator validates against the declared 3.0.1 version, so `const` is rejected regardless of generator version. This is effectively an upstream spec bug (a 3.1 keyword in a 3.0.1 document).

## Fix

Extend the existing `scripts/normalize_openapi_schema.py` normalization step to strip the inline scalar `const` keyword (semantically a single-value enum), leaving the valid `type:`/`description:` a 3.0 document expects. This matches the repo's existing pattern of normalizing known upstream schema issues, and keeps generator spec validation enabled.

The stripping is deliberately conservative to avoid touching:
- properties literally named `const` (bare `const:`, comment-only, or quoted keys)
- `const:` text appearing inside YAML block scalars (`description: |` bodies), including sequence-item and both indicator orderings (`|2-`, `>4+`)
- collection-valued const (block-form or inline flow `{...}`/`[...]`) — documented limitation; upstream only uses inline scalar const, and validation fails loudly if that changes

## Verification

- `openapi-generator-cli v7.22.0 validate` **passes** on the normalized upstream spec (fails on the raw spec with the exact CI error)
- Full `generate-openapi-client.sh` run completes end-to-end; the affected field generates as a plain `r#type: String`
- 11 unit tests in `tests/test_normalize_openapi_schema.py` cover the stripping and all preservation cases above